### PR TITLE
Add manual price input for turnos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,24 @@
 // src/App.jsx
 
 import React, { useEffect, useState } from "react";
-import { Routes, Route, Navigate } from "react-router-dom"; 
+import { Routes, Route, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import AddTurno from "./pages/AddTurno";
 import EditTurno from "./pages/EditTurno";
 import Login from "./pages/Login";
-// ¡Importamos la nueva página de Finanzas!
-import Finances from "./pages/Finances"; // <-- NUEVA IMPORTACIÓN
+import Finances from "./pages/Finances";
 
 import Navbar from "./components/Navbar";
 
 import { auth } from "./firebase/config";
 import { onAuthStateChanged } from "firebase/auth";
 
-// PrivateRoute está perfecto, no necesita cambios.
 function PrivateRoute({ user, children }) {
   if (user === undefined) {
     return (
       <div className="d-flex justify-content-center align-items-center" style={{ height: '80vh' }}>
         <div className="spinner-border" role="status">
           <span className="visually-hidden">Cargando...</span>
-        ientos/div>
         </div>
       </div>
     );
@@ -46,14 +43,13 @@ function App() {
       <main className="flex-grow-1 mt-3">
         <Routes>
           <Route path="/login" element={<Login />} />
-          
+
           <Route path="/" element={<PrivateRoute user={currentUser}><Home /></PrivateRoute>} />
           <Route path="/nuevo" element={<PrivateRoute user={currentUser}><AddTurno /></PrivateRoute>} />
           <Route path="/edit-turno/:id" element={<PrivateRoute user={currentUser}><EditTurno /></PrivateRoute>} />
-          
-          {/* ¡NUEVA RUTA para la sección de Finanzas! */}
-          <Route path="/finanzas" element={<PrivateRoute user={currentUser}><Finances /></PrivateRoute>} /> {/* <-- NUEVA RUTA */}
-          
+
+          <Route path="/finanzas" element={<PrivateRoute user={currentUser}><Finances /></PrivateRoute>} />
+
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>
       </main>
@@ -62,3 +58,4 @@ function App() {
 }
 
 export default App;
+

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -11,9 +11,8 @@ const SERVICES_OPTIONS = [
 ];
 
 function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText }) {
-  // Ya no desestructuramos 'precio' directamente, ya que no es un input directo aquí.
-  // Pero 'servicio' sí lo es.
-  const { nombre, fecha, hora, servicio } = turnoData; 
+  // Desestructuramos todos los campos, incluido "precio" para el input numérico.
+  const { nombre, fecha, hora, servicio, precio } = turnoData;
 
   return (
     <form onSubmit={onSubmit}>
@@ -70,6 +69,19 @@ function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText }) 
             </option>
           ))}
         </select>
+      </div>
+
+      <div className="mb-3">
+        <label htmlFor="precio" className="form-label">Precio</label>
+        <input
+          type="number"
+          className="form-control"
+          id="precio"
+          name="precio"
+          value={precio}
+          onChange={onFormChange}
+          required
+        />
       </div>
 
       <button type="submit" className="btn btn-primary w-100" disabled={isSaving}>

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -34,11 +34,14 @@ function AddTurno() {
     if (name === 'servicio') {
       // Si el campo que cambia es el servicio, actualizamos el precio automáticamente
       const selectedPrice = SERVICES_PRICES[value] || 0; // Asignamos el precio del servicio seleccionado
-      setTurno(prevTurno => ({ 
-        ...prevTurno, 
+      setTurno(prevTurno => ({
+        ...prevTurno,
         servicio: value, // Actualizamos el servicio
         precio: selectedPrice // Actualizamos el precio
       }));
+    } else if (name === 'precio') {
+      // Permitimos cambiar manualmente el precio desde el input
+      setTurno(prevTurno => ({ ...prevTurno, precio: value }));
     } else {
       // Para otros campos, solo actualizamos el valor
       setTurno(prevTurno => ({ ...prevTurno, [name]: value }));

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -58,11 +58,14 @@ function EditTurno() {
     if (name === 'servicio') {
       // Si el campo que cambia es el servicio, actualizamos el precio automáticamente
       const selectedPrice = SERVICES_PRICES[value] || 0; // Asignamos el precio del servicio seleccionado
-      setTurno(prevTurno => ({ 
-        ...prevTurno, 
+      setTurno(prevTurno => ({
+        ...prevTurno,
         servicio: value, // Actualizamos el servicio
         precio: selectedPrice // Actualizamos el precio
       }));
+    } else if (name === 'precio') {
+      // Permitimos cambiar manualmente el precio desde el input
+      setTurno(prevTurno => ({ ...prevTurno, precio: value }));
     } else {
       // Para otros campos, solo actualizamos el valor
       setTurno(prevTurno => ({ ...prevTurno, [name]: value }));

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
 import { db } from '../firebase/config';
-import toast from 'react-hot-toast';
 
 function Finances() {
     const [allTurnos, setAllTurnos] = useState([]);


### PR DESCRIPTION
## Summary
- add numeric `precio` field to TurnoForm
- allow editing price manually while keeping automatic service pricing in AddTurno/EditTurno
- fix lint issues in App and Finances

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e7483c5b0832c90a0b36233c229b0