### PR TITLE
Add Firestore-backed services management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import AddTurno from "./pages/AddTurno";
 import EditTurno from "./pages/EditTurno";
 import Login from "./pages/Login";
 import Finances from "./pages/Finances";
+import ManageServices from "./pages/ManageServices";
 
 import Navbar from "./components/Navbar";
 
@@ -49,6 +50,7 @@ function App() {
           <Route path="/edit-turno/:id" element={<PrivateRoute user={currentUser}><EditTurno /></PrivateRoute>} />
 
           <Route path="/finanzas" element={<PrivateRoute user={currentUser}><Finances /></PrivateRoute>} />
+          <Route path="/services" element={<PrivateRoute user={currentUser}><ManageServices /></PrivateRoute>} />
 
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>

--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -2,15 +2,7 @@
 
 import React from 'react';
 
-// Definimos los servicios y sus precios aqui para que TurnoForm los conozca.
-// Los usaremos en el selector.
-const SERVICES_OPTIONS = [
-  { value: '', label: 'Seleccione un servicio', price: 0 }, // Opción por defecto
-  { value: 'Corte de Cabello', label: 'Corte de Cabello', price: 8000 },
-  { value: 'Corte y Barba', label: 'Corte y Barba', price: 10000 },
-];
-
-function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText }) {
+function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, services = [] }) {
   // Desestructuramos todos los campos, incluido "precio" para el input numérico.
   const { nombre, fecha, hora, servicio, precio } = turnoData;
 
@@ -56,16 +48,17 @@ function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText }) 
       <div className="mb-4"> {/* CAMPO SERVICIO AHORA ES UN SELECT */}
         <label htmlFor="servicio" className="form-label">Servicio</label>
         <select
-          className="form-select" // Clase de Bootstrap para select
+          className="form-select"
           id="servicio"
           name="servicio"
           value={servicio}
           onChange={onFormChange}
-          required // Hacemos que la selección del servicio sea obligatoria
+          required
         >
-          {SERVICES_OPTIONS.map(option => (
-            <option key={option.value} value={option.value} disabled={option.value === ''}>
-              {option.label}
+          <option value="" disabled>Seleccione un servicio</option>
+          {services.map((s) => (
+            <option key={s.id} value={s.nombre}>
+              {s.nombre}
             </option>
           ))}
         </select>

--- a/src/pages/ManageServices.jsx
+++ b/src/pages/ManageServices.jsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import { collection, addDoc, getDocs, doc, updateDoc, deleteDoc } from 'firebase/firestore';
+import { db } from '../firebase/config';
+import toast from 'react-hot-toast';
+
+function ManageServices() {
+  const [services, setServices] = useState([]);
+  const [form, setForm] = useState({ nombre: '', precio: '' });
+  const [editingId, setEditingId] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchServices = async () => {
+    try {
+      const snapshot = await getDocs(collection(db, 'services'));
+      const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      setServices(data);
+    } catch (err) {
+      console.error('Error fetching services:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchServices();
+  }, []);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.nombre.trim()) {
+      toast.error('El nombre es obligatorio');
+      return;
+    }
+    setLoading(true);
+    try {
+      if (editingId) {
+        await updateDoc(doc(db, 'services', editingId), {
+          nombre: form.nombre,
+          precio: Number(form.precio),
+        });
+        toast.success('Servicio actualizado');
+      } else {
+        await addDoc(collection(db, 'services'), {
+          nombre: form.nombre,
+          precio: Number(form.precio),
+        });
+        toast.success('Servicio agregado');
+      }
+      setForm({ nombre: '', precio: '' });
+      setEditingId(null);
+      fetchServices();
+    } catch (err) {
+      console.error('Error saving service:', err);
+      toast.error('Error al guardar el servicio');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEdit = (service) => {
+    setForm({ nombre: service.nombre, precio: service.precio });
+    setEditingId(service.id);
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm('¿Eliminar servicio?')) return;
+    try {
+      await deleteDoc(doc(db, 'services', id));
+      toast.success('Servicio eliminado');
+      fetchServices();
+    } catch (err) {
+      console.error('Error deleting service:', err);
+      toast.error('Error al eliminar el servicio');
+    }
+  };
+
+  return (
+    <div className="container mt-4" style={{ maxWidth: '600px' }}>
+      <h2 className="mb-4">Servicios</h2>
+      <form onSubmit={handleSubmit} className="mb-4">
+        <div className="mb-3">
+          <label htmlFor="nombre" className="form-label">Nombre</label>
+          <input
+            type="text"
+            id="nombre"
+            name="nombre"
+            className="form-control"
+            value={form.nombre}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="precio" className="form-label">Precio</label>
+          <input
+            type="number"
+            id="precio"
+            name="precio"
+            className="form-control"
+            value={form.precio}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <button type="submit" className="btn btn-primary w-100" disabled={loading}>
+          {loading ? 'Guardando...' : editingId ? 'Actualizar' : 'Agregar'}
+        </button>
+      </form>
+
+      <ul className="list-group">
+        {services.map((service) => (
+          <li key={service.id} className="list-group-item d-flex justify-content-between align-items-center">
+            <span>
+              {service.nombre} - ${service.precio}
+            </span>
+            <div>
+              <button className="btn btn-sm btn-outline-secondary me-2" onClick={() => handleEdit(service)}>
+                Editar
+              </button>
+              <button className="btn btn-sm btn-outline-danger" onClick={() => handleDelete(service.id)}>
+                Eliminar
+              </button>
+            </div>
+          </li>
+        ))}
+        {services.length === 0 && <li className="list-group-item text-center">No hay servicios</li>}
+      </ul>
+    </div>
+  );
+}
+
+export default ManageServices;
+


### PR DESCRIPTION
## Summary
- add ManageServices page for CRUD operations on services collection
- load available services from Firestore in turn forms and auto-fill prices
- route services manager through authenticated path

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ed4e5d2b8832cba73b49360ec9510