### PR TITLE
feat: allow adding services from TurnoForm

### DIFF
--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -1,12 +1,65 @@
 // src/components/TurnoForm.jsx
 
-import React from 'react';
+import React, { useState } from 'react';
+import { collection, addDoc, getDocs, query, where } from 'firebase/firestore';
+import { db } from '../firebase/config';
+import toast from 'react-hot-toast';
 
-function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, services = [] }) {
+function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, services = [], reloadServices }) {
   // Desestructuramos todos los campos, incluido "precio" para el input numérico.
   const { nombre, fecha, hora, servicio, precio } = turnoData;
 
+  const [showModal, setShowModal] = useState(false);
+  const [newService, setNewService] = useState({ nombre: '', precio: '' });
+  const [savingService, setSavingService] = useState(false);
+
+  const openModal = () => setShowModal(true);
+  const closeModal = () => {
+    setShowModal(false);
+    setNewService({ nombre: '', precio: '' });
+  };
+
+  const handleNewServiceChange = (e) => {
+    const { name, value } = e.target;
+    setNewService((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleNewServiceSubmit = async (e) => {
+    e.preventDefault();
+    if (!newService.nombre.trim()) {
+      toast.error('El nombre es obligatorio');
+      return;
+    }
+    setSavingService(true);
+    try {
+      const q = query(collection(db, 'services'), where('nombre', '==', newService.nombre));
+      const existing = await getDocs(q);
+      if (!existing.empty) {
+        toast.error('Ya existe un servicio con ese nombre');
+        setSavingService(false);
+        return;
+      }
+      await addDoc(collection(db, 'services'), {
+        nombre: newService.nombre,
+        precio: Number(newService.precio),
+      });
+      toast.success('Servicio agregado');
+      if (reloadServices) {
+        await reloadServices();
+      }
+      onFormChange({ target: { name: 'servicio', value: newService.nombre } });
+      onFormChange({ target: { name: 'precio', value: newService.precio } });
+      closeModal();
+    } catch (err) {
+      console.error('Error al agregar servicio:', err);
+      toast.error('Error al agregar servicio');
+    } finally {
+      setSavingService(false);
+    }
+  };
+
   return (
+    <>
     <form onSubmit={onSubmit}>
       <div className="mb-3">
         <label htmlFor="nombre" className="form-label">Nombre del Cliente</label>
@@ -62,6 +115,9 @@ function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, se
             </option>
           ))}
         </select>
+        <button type="button" className="btn btn-sm btn-outline-primary mt-2" onClick={openModal}>
+          Agregar servicio
+        </button>
       </div>
 
       <div className="mb-3">
@@ -81,6 +137,58 @@ function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, se
         {isSaving ? 'Guardando...' : submitText}
       </button>
     </form>
+    {showModal && (
+      <>
+        <div className="modal fade show" style={{ display: 'block' }} tabIndex="-1">
+          <div className="modal-dialog">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">Nuevo Servicio</h5>
+                <button type="button" className="btn-close" onClick={closeModal}></button>
+              </div>
+              <form onSubmit={handleNewServiceSubmit}>
+                <div className="modal-body">
+                  <div className="mb-3">
+                    <label htmlFor="nuevo-nombre" className="form-label">Nombre</label>
+                    <input
+                      type="text"
+                      id="nuevo-nombre"
+                      name="nombre"
+                      className="form-control"
+                      value={newService.nombre}
+                      onChange={handleNewServiceChange}
+                      required
+                    />
+                  </div>
+                  <div className="mb-3">
+                    <label htmlFor="nuevo-precio" className="form-label">Precio</label>
+                    <input
+                      type="number"
+                      id="nuevo-precio"
+                      name="precio"
+                      className="form-control"
+                      value={newService.precio}
+                      onChange={handleNewServiceChange}
+                      required
+                    />
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-secondary" onClick={closeModal} disabled={savingService}>
+                    Cancelar
+                  </button>
+                  <button type="submit" className="btn btn-primary" disabled={savingService}>
+                    {savingService ? 'Guardando...' : 'Guardar'}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div className="modal-backdrop fade show"></div>
+      </>
+    )}
+    </>
   );
 }
 

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -23,21 +23,22 @@ function AddTurno() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
+  const fetchServices = async () => {
+    try {
+      const snapshot = await getDocs(collection(db, 'services'));
+      const servicesData = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      setServices(servicesData);
+      const prices = {};
+      servicesData.forEach((s) => {
+        prices[s.nombre] = s.precio;
+      });
+      setServicePrices(prices);
+    } catch (err) {
+      console.error('Error fetching services:', err);
+    }
+  };
+
   useEffect(() => {
-    const fetchServices = async () => {
-      try {
-        const snapshot = await getDocs(collection(db, 'services'));
-        const servicesData = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-        setServices(servicesData);
-        const prices = {};
-        servicesData.forEach((s) => {
-          prices[s.nombre] = s.precio;
-        });
-        setServicePrices(prices);
-      } catch (err) {
-        console.error('Error fetching services:', err);
-      }
-    };
     fetchServices();
   }, []);
 
@@ -112,6 +113,7 @@ function AddTurno() {
         isSaving={loading}
         submitText="Guardar Turno"
         services={services}
+        reloadServices={fetchServices}
       />
     </div>
   );

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -15,18 +15,25 @@ function EditTurno() {
   const [isSaving, setIsSaving] = useState(false);
   const [services, setServices] = useState([]);
   const [servicePrices, setServicePrices] = useState({});
+  const fetchServices = async () => {
+    try {
+      const servicesSnap = await getDocs(collection(db, 'services'));
+      const servicesData = servicesSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      setServices(servicesData);
+      const prices = {};
+      servicesData.forEach((s) => {
+        prices[s.nombre] = s.precio;
+      });
+      setServicePrices(prices);
+    } catch (err) {
+      console.error('Error fetching services:', err);
+    }
+  };
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const servicesSnap = await getDocs(collection(db, 'services'));
-        const servicesData = servicesSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-        setServices(servicesData);
-        const prices = {};
-        servicesData.forEach((s) => {
-          prices[s.nombre] = s.precio;
-        });
-        setServicePrices(prices);
+        await fetchServices();
 
         const turnoDoc = await getDoc(doc(db, 'turnos', id));
         if (turnoDoc.exists()) {
@@ -138,6 +145,7 @@ function EditTurno() {
             isSaving={isSaving}
             submitText="Actualizar Turno"
             services={services}
+            reloadServices={fetchServices}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- allow adding new services from TurnoForm
- reload service options after creating a service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ed656a950832cac4b84fbc4a6c7b4