### PR TITLE
feat: centralize service loading with hook

### DIFF
--- a/src/components/TurnoForm.jsx
+++ b/src/components/TurnoForm.jsx
@@ -5,7 +5,7 @@ import { collection, addDoc, getDocs, query, where } from 'firebase/firestore';
 import { db } from '../firebase/config';
 import toast from 'react-hot-toast';
 
-function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, services = [], reloadServices }) {
+function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, services = [], reload }) {
   // Desestructuramos todos los campos, incluido "precio" para el input numérico.
   const { nombre, fecha, hora, servicio, precio } = turnoData;
 
@@ -44,8 +44,8 @@ function TurnoForm({ turnoData, onFormChange, onSubmit, isSaving, submitText, se
         precio: Number(newService.precio),
       });
       toast.success('Servicio agregado');
-      if (reloadServices) {
-        await reloadServices();
+      if (reload) {
+        await reload();
       }
       onFormChange({ target: { name: 'servicio', value: newService.nombre } });
       onFormChange({ target: { name: 'precio', value: newService.precio } });

--- a/src/hooks/useServices.js
+++ b/src/hooks/useServices.js
@@ -1,0 +1,31 @@
+import { useState, useEffect, useCallback } from 'react';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase/config';
+
+function useServices() {
+  const [services, setServices] = useState([]);
+  const [servicePrices, setServicePrices] = useState({});
+
+  const load = useCallback(async () => {
+    try {
+      const snapshot = await getDocs(collection(db, 'services'));
+      const data = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      setServices(data);
+      const prices = {};
+      data.forEach((s) => {
+        prices[s.nombre] = s.precio;
+      });
+      setServicePrices(prices);
+    } catch (err) {
+      console.error('Error fetching services:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { services, servicePrices, reload: load };
+}
+
+export default useServices;

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -1,11 +1,12 @@
 // src/pages/AddTurno.jsx
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { collection, addDoc, Timestamp, query, where, getDocs } from 'firebase/firestore';
 import { db } from '../firebase/config';
 import { useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';
 import toast from 'react-hot-toast';
+import useServices from '../hooks/useServices';
 
 // Estado inicial: Ahora incluimos el servicio por defecto y el precio correspondiente
 const initialState = {
@@ -18,29 +19,9 @@ const initialState = {
 
 function AddTurno() {
   const [turno, setTurno] = useState(initialState);
-  const [services, setServices] = useState([]);
-  const [servicePrices, setServicePrices] = useState({});
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-
-  const fetchServices = async () => {
-    try {
-      const snapshot = await getDocs(collection(db, 'services'));
-      const servicesData = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-      setServices(servicesData);
-      const prices = {};
-      servicesData.forEach((s) => {
-        prices[s.nombre] = s.precio;
-      });
-      setServicePrices(prices);
-    } catch (err) {
-      console.error('Error fetching services:', err);
-    }
-  };
-
-  useEffect(() => {
-    fetchServices();
-  }, []);
+  const { services, servicePrices, reload } = useServices();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -113,7 +94,7 @@ function AddTurno() {
         isSaving={loading}
         submitText="Guardar Turno"
         services={services}
-        reloadServices={fetchServices}
+        reload={reload}
       />
     </div>
   );

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -6,6 +6,7 @@ import { db } from '../firebase/config';
 import { useParams, useNavigate } from 'react-router-dom';
 import TurnoForm from '../components/TurnoForm';
 import toast from 'react-hot-toast';
+import useServices from '../hooks/useServices';
 
 function EditTurno() {
   const { id } = useParams();
@@ -13,28 +14,11 @@ function EditTurno() {
   const [turno, setTurno] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
-  const [services, setServices] = useState([]);
-  const [servicePrices, setServicePrices] = useState({});
-  const fetchServices = async () => {
-    try {
-      const servicesSnap = await getDocs(collection(db, 'services'));
-      const servicesData = servicesSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-      setServices(servicesData);
-      const prices = {};
-      servicesData.forEach((s) => {
-        prices[s.nombre] = s.precio;
-      });
-      setServicePrices(prices);
-    } catch (err) {
-      console.error('Error fetching services:', err);
-    }
-  };
+  const { services, servicePrices, reload } = useServices();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        await fetchServices();
-
         const turnoDoc = await getDoc(doc(db, 'turnos', id));
         if (turnoDoc.exists()) {
           const data = turnoDoc.data();
@@ -145,7 +129,7 @@ function EditTurno() {
             isSaving={isSaving}
             submitText="Actualizar Turno"
             services={services}
-            reloadServices={fetchServices}
+            reload={reload}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- add `useServices` hook to centralize service collection and expose reload
- refactor AddTurno/EditTurno to consume hook and pass reload to TurnoForm
- let TurnoForm trigger service reload after creating a new service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eda047590832c9b94bda0d50da43f