### PR TITLE
Add turno completion tracking and counter

### DIFF
--- a/src/components/TurnoCard.jsx
+++ b/src/components/TurnoCard.jsx
@@ -2,9 +2,22 @@
 
 import React from 'react';
 import { FaEdit, FaTrashAlt } from 'react-icons/fa';
+import { doc, updateDoc } from 'firebase/firestore';
+import { db } from '../firebase/config';
+import toast from 'react-hot-toast';
 
 function TurnoCard({ turno, onDelete, onEdit }) {
-  const { id, nombre, hora, servicio } = turno; // Mantenemos servicio aquí por si lo usamos en el 'title'
+  const { id, nombre, hora, servicio, completado } = turno; // Mantenemos servicio aquí por si lo usamos en el 'title'
+
+  const handleCompletado = async () => {
+    try {
+      await updateDoc(doc(db, 'turnos', id), { completado: true });
+      toast.success('Turno completado');
+    } catch (err) {
+      console.error('Error al marcar como completado:', err);
+      toast.error('No se pudo marcar como completado');
+    }
+  };
 
   return (
     <div className="turno-row">
@@ -29,6 +42,15 @@ function TurnoCard({ turno, onDelete, onEdit }) {
           className="btn btn-sm btn-outline-danger"
         >
           <FaTrashAlt />
+        </button>
+        <button
+          type="button"
+          aria-label="Marcar como completado"
+          onClick={handleCompletado}
+          className="btn btn-sm btn-outline-success"
+          disabled={completado}
+        >
+          Completado
         </button>
       </div>
     </div>

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -14,7 +14,8 @@ const initialState = {
   fecha: '',
   hora: '',
   servicio: '', // Servicio inicial vacío para obligar a la selección
-  precio: 0 // Precio inicial 0, se actualizará al seleccionar un servicio
+  precio: 0, // Precio inicial 0, se actualizará al seleccionar un servicio
+  completado: false // Estado inicial del turno
 };
 
 function AddTurno() {
@@ -71,8 +72,11 @@ function AddTurno() {
       // Aseguramos que se guarde como número.
       const precioNumerico = parseFloat(turno.precio); 
 
-      // Guardamos el turno con el precio (ya calculado)
-      await addDoc(collection(db, "turnos"), { ...turno, precio: precioNumerico, creado: Timestamp.now() });
+      // Guardamos el turno con el precio (ya calculado) y marcado como pendiente
+      await addDoc(
+        collection(db, "turnos"),
+        { ...turno, precio: precioNumerico, completado: false, creado: Timestamp.now() }
+      );
       toast.success('Turno guardado con éxito');
       navigate('/');
 

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -25,6 +25,7 @@ function EditTurno() {
           setTurno({
             id: turnoDoc.id,
             ...data,
+            completado: data.completado ?? false,
             servicio: data.servicio || '',
             precio: data.precio !== undefined ? String(data.precio) : '0',
           });

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -45,6 +45,11 @@ function Home() {
     return allTurnos.filter(turno => turno.fecha === dateString);
   }, [selectedDate, allTurnos]);
 
+  const completedCount = useMemo(
+    () => filteredTurnos.filter(t => t.completado).length,
+    [filteredTurnos]
+  );
+
   // NUEVO: Lógica para identificar turnos próximos (para el día de hoy)
   const todayTurnos = useMemo(() => {
     // Obtener la fecha actual en formato 'YYYY-MM-DD'
@@ -120,10 +125,13 @@ function Home() {
       {/* FIN NUEVO */}
 
       <h2 className="mb-3 text-white">Tu Agenda</h2>
-      <CalendarView 
+      <div className="text-white mb-3">
+        Cortes completados: {completedCount} / {filteredTurnos.length}
+      </div>
+      <CalendarView
         onDateChange={handleDateChange}
         selectedDate={selectedDate}
-        turnos={allTurnos} 
+        turnos={allTurnos}
       />
       <h3 className="mb-3 mt-4 text-white">
         {selectedDate && `Turnos para el ${selectedDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}`}


### PR DESCRIPTION
## Summary
- track completion state when creating and editing turnos
- allow marking a turno as completed from the list
- display completed vs total counts for selected day

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a14c7bc1ec832c8f2bb713eb7c55d8