### PR TITLE
Eliminar lógica de completado

### DIFF
--- a/scripts/removeCompletado.js
+++ b/scripts/removeCompletado.js
@@ -1,0 +1,15 @@
+import { collection, getDocs, updateDoc, doc, deleteField } from 'firebase/firestore';
+import { db } from '../src/firebase/config.js';
+
+async function removeCompletado() {
+  const snapshot = await getDocs(collection(db, 'turnos'));
+  const updates = snapshot.docs.map(d => updateDoc(doc(db, 'turnos', d.id), {
+    completado: deleteField()
+  }));
+  await Promise.all(updates);
+  console.log('Propiedad "completado" eliminada de todos los turnos.');
+}
+
+removeCompletado().catch(err => {
+  console.error('Error en la migración:', err);
+});

--- a/src/components/TurnoCard.jsx
+++ b/src/components/TurnoCard.jsx
@@ -2,22 +2,9 @@
 
 import React from 'react';
 import { FaEdit, FaTrashAlt } from 'react-icons/fa';
-import { doc, updateDoc } from 'firebase/firestore';
-import { db } from '../firebase/config';
-import toast from 'react-hot-toast';
 
 function TurnoCard({ turno, onDelete, onEdit }) {
-  const { id, nombre, hora, servicio, completado } = turno; // Mantenemos servicio aquí por si lo usamos en el 'title'
-
-  const handleCompletado = async () => {
-    try {
-      await updateDoc(doc(db, 'turnos', id), { completado: true });
-      toast.success('Turno completado');
-    } catch (err) {
-      console.error('Error al marcar como completado:', err);
-      toast.error('No se pudo marcar como completado');
-    }
-  };
+  const { id, nombre, hora, servicio } = turno; // Mantenemos servicio aquí por si lo usamos en el 'title'
 
   return (
     <div className="turno-row">
@@ -42,15 +29,6 @@ function TurnoCard({ turno, onDelete, onEdit }) {
           className="btn btn-sm btn-outline-danger"
         >
           <FaTrashAlt />
-        </button>
-        <button
-          type="button"
-          aria-label="Marcar como completado"
-          onClick={handleCompletado}
-          className="btn btn-sm btn-outline-success"
-          disabled={completado}
-        >
-          Completado
         </button>
       </div>
     </div>

--- a/src/pages/AddTurno.jsx
+++ b/src/pages/AddTurno.jsx
@@ -14,8 +14,7 @@ const initialState = {
   fecha: '',
   hora: '',
   servicio: '', // Servicio inicial vacío para obligar a la selección
-  precio: 0, // Precio inicial 0, se actualizará al seleccionar un servicio
-  completado: false // Estado inicial del turno
+  precio: 0 // Precio inicial 0, se actualizará al seleccionar un servicio
 };
 
 function AddTurno() {
@@ -72,10 +71,10 @@ function AddTurno() {
       // Aseguramos que se guarde como número.
       const precioNumerico = parseFloat(turno.precio); 
 
-      // Guardamos el turno con el precio (ya calculado) y marcado como pendiente
+      // Guardamos el turno con el precio (ya calculado)
       await addDoc(
         collection(db, "turnos"),
-        { ...turno, precio: precioNumerico, completado: false, creado: Timestamp.now() }
+        { ...turno, precio: precioNumerico, creado: Timestamp.now() }
       );
       toast.success('Turno guardado con éxito');
       navigate('/');

--- a/src/pages/EditTurno.jsx
+++ b/src/pages/EditTurno.jsx
@@ -24,8 +24,9 @@ function EditTurno() {
           const data = turnoDoc.data();
           setTurno({
             id: turnoDoc.id,
-            ...data,
-            completado: data.completado ?? false,
+            nombre: data.nombre || '',
+            fecha: data.fecha || '',
+            hora: data.hora || '',
             servicio: data.servicio || '',
             precio: data.precio !== undefined ? String(data.precio) : '0',
           });

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -45,11 +45,6 @@ function Home() {
     return allTurnos.filter(turno => turno.fecha === dateString);
   }, [selectedDate, allTurnos]);
 
-  const completedCount = useMemo(
-    () => filteredTurnos.filter(t => t.completado).length,
-    [filteredTurnos]
-  );
-
   // NUEVO: Lógica para identificar turnos próximos (para el día de hoy)
   const todayTurnos = useMemo(() => {
     // Obtener la fecha actual en formato 'YYYY-MM-DD'
@@ -126,7 +121,7 @@ function Home() {
 
       <h2 className="mb-3 text-white">Tu Agenda</h2>
       <div className="text-white mb-3">
-        Cortes completados: {completedCount} / {filteredTurnos.length}
+        Total de cortes: {filteredTurnos.length}
       </div>
       <CalendarView
         onDateChange={handleDateChange}


### PR DESCRIPTION
## Resumen
- Quitar el campo `completado` de la creación y edición de turnos.
- Eliminar el botón de marcado como completado en las tarjetas de turno.
- Mostrar solo el total de turnos filtrados en la agenda.
- Añadir script opcional para eliminar la propiedad `completado` de documentos existentes en Firestore.

## Pruebas
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a14f013d10832c8d7771df318cf11b