### PR TITLE
Fix cortesCompletados fallback logic

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -46,7 +46,10 @@ function Home() {
     return allTurnos.filter(turno => turno.fecha === dateString);
   }, [selectedDate, allTurnos]);
 
-  const cortesCompletados = useMemo(() => filteredTurnos.filter(t => t.completado), [filteredTurnos]);
+  const cortesCompletados = useMemo(() => {
+    const completados = filteredTurnos.filter(t => t.completado);
+    return completados.length ? completados : filteredTurnos;
+  }, [filteredTurnos]);
   const gananciaDiaria = useMemo(
     () => cortesCompletados.reduce((s, t) => s + (parseFloat(t.precio) || 0), 0),
     [cortesCompletados]


### PR DESCRIPTION
## Summary
- Ensure completed cuts fallback to all filtered appointments when no `completado` flags exist
- Keep daily earnings calculated from `cortesCompletados`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a15598a948832ca018c3f911a5128a