### PR TITLE
Actualizar servicios de corte a Cabello

### DIFF
--- a/src/hooks/useServices.js
+++ b/src/hooks/useServices.js
@@ -4,16 +4,16 @@ import { useMemo } from 'react';
 function useServices() {
   const services = useMemo(
     () => [
-      { id: 'corte', nombre: 'Corte de pelo' },
-      { id: 'corte-barba', nombre: 'Corte de pelo y barba' },
+      { id: 'corte', nombre: 'Corte de Cabello' },
+      { id: 'corte-barba', nombre: 'Corte de Cabello y Barba' },
     ],
     []
   );
 
   const servicePrices = useMemo(
     () => ({
-      'Corte de pelo': 9000,
-      'Corte de pelo y barba': 12000,
+      'Corte de Cabello': 9000,
+      'Corte de Cabello y Barba': 12000,
     }),
     []
   );

--- a/src/pages/Finances.jsx
+++ b/src/pages/Finances.jsx
@@ -100,7 +100,7 @@ function Finances() {
             total += parseFloat(turno.precio || 0);
 
             // NUEVO: Contamos solo si el servicio es un tipo de corte
-            if (turno.servicio === 'Corte de Cabello' || turno.servicio === 'Corte y Barba') {
+            if (turno.servicio === 'Corte de Cabello' || turno.servicio === 'Corte de Cabello y Barba') {
                 cortesCount++;
             }
         });


### PR DESCRIPTION
## Summary
- Actualizar nombres y precios de servicios a Corte de Cabello y Corte de Cabello y Barba
- Ajustar conteo de cortes en finanzas para nuevos nombres de servicios
- Reemplazar todas las ocurrencias de 'pelo' por 'cabello'

## Testing
- `npm test` *(missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a156deb758832cbae96c5fc771aa2a